### PR TITLE
Edit: Restrict categorization to root-level files in Drive

### DIFF
--- a/backend/modules/organizer/categorizer.py
+++ b/backend/modules/organizer/categorizer.py
@@ -10,7 +10,7 @@ def process_all_drive_files():
         "application/pdf",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     ] + image_mimes])
-    query = f"({mime_query}) and trashed=false" # and 'root' in parents"
+    query = f"({mime_query}) and trashed=false and 'root' in parents"
     results = drive_service.files().list(
         q=query,
         fields="files(id, name, mimeType)"


### PR DESCRIPTION
- Updated the file query in categorizer.py to filter and process only those files that are directly located in the root directory of the connected Google Drive.
- This change ensures that the categorizer only processes files that are currently not inside any folder. This helps avoid:
+ Reprocessing already organized files
+ Duplicate folder nesting
+ Unintended movement of files that are already categorized

This aligns with the expected behavior of the automation: to act only on uncategorized files sitting in the Drive root.